### PR TITLE
Don't set `LC_TYPE`

### DIFF
--- a/lib/translation.rb
+++ b/lib/translation.rb
@@ -27,8 +27,7 @@ module TranslationIO
     attr_reader :config, :client
 
     def configure(&block)
-      ENV['LANG']     = 'en_US.UTF-8' if ENV['LANG'].blank?
-      ENV['LC_CTYPE'] = 'UTF-8'       if ENV['LC_CTYPE'].blank?
+      ENV['LANG'] = 'en_US.UTF-8' if ENV['LANG'].blank?
 
       @config ||= Config.new
 


### PR DESCRIPTION
Setting `LANG` already defines a value for all locale purposes, so we
don't need to specifically set `LC_TYPE` ([reference]). Specially, not
to an invalid locale... :wink:

This fixes several warnings when using this gem in Linux. For example,

```
invalid byte sequence in US-ASCII While processing ...
```

or

```
Fontconfig warning: ignoring UTF-8: not a valid region tag
```

[reference]: https://www.gnu.org/savannah-checkouts/gnu/libc/manual/html_node/Locale-Categories.html