### PR TITLE
Exit with failure status code as opposed to implicit success in rescue blocks

### DIFF
--- a/lib/translation_io/client/base_operation.rb
+++ b/lib/translation_io/client/base_operation.rb
@@ -39,14 +39,14 @@ module TranslationIO
             return parsed_response
           elsif response.code.to_i == 400 && parsed_response.has_key?('error')
             $stderr.puts "[Error] #{parsed_response['error']}"
-            exit
+            exit(false)
           else
             $stderr.puts "[Error] Unknown error from the server: #{response.code}."
-            exit
+            exit(false)
           end
         rescue Errno::ECONNREFUSED
           $stderr.puts "[Error] Server not responding."
-          exit
+          exit(false)
         end
       end
 

--- a/lib/translation_io/client/sync_operation/apply_yaml_source_edits_step.rb
+++ b/lib/translation_io/client/sync_operation/apply_yaml_source_edits_step.rb
@@ -78,7 +78,7 @@ module TranslationIO
 
             if metadata_content.include?('>>>>') || metadata_content.include?('<<<<')
               TranslationIO.info "[Error] #{TranslationIO.config.metadata_path} file is corrupted and seems to have unresolved versioning conflicts. Please resolve them and try again."
-              exit
+              exit(false)
             else
               return YAML::load(metadata_content)['timestamp'] rescue 0
             end


### PR DESCRIPTION
Explicitly return a fail code so dependent services can handle API errors and other such locking problems.

Failing silently allows a deployment to proceed without warning, despite translations failing.

edit: There are no contribution guidelines, feel free to advise me how to proceed.